### PR TITLE
remove the need to add parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ pip install ruamel.yaml
 ```
 
 ## Usage
-For now we're piggy-backing on [dbt-sa-cli](https://github.com/dbt-labs/dbt-sa-cli) for command-line interface functionality. So you still have to pass a parse argument.
+For now we're piggy-backing on [dbt-sa-cli](https://github.com/dbt-labs/dbt-sa-cli) for command-line interface functionality.
 
 ``` bash
-dbt-lint-yaml parse
+dbt-lint-yaml
 # or if you want auto fixes
-dbt-lint-yaml parse --fix
+dbt-lint-yaml --fix
 ```
 
 The rules are controlled by a `dbt-lint.yml` file in the root of your dbt project. 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,10 @@ fn extract_shimmed_flags(args: Vec<OsString>) -> (Vec<OsString>, bool, bool) {
             fix = true;
             continue;
         }
+        if arg == "parse" {
+            // skip parse so it's backwards compatible with prior CLI
+            continue;
+        }
         filtered.push(arg);
     }
 
@@ -120,7 +124,8 @@ async fn main() -> FsResult<()> {
     maybe_handle_version_override();
 
     let raw_args: Vec<OsString> = std::env::args_os().collect();
-    let (filtered_args, verbose, fix_flag) = extract_shimmed_flags(raw_args);
+    let (mut filtered_args, verbose, fix_flag) = extract_shimmed_flags(raw_args);
+    filtered_args.insert(1, OsString::from("parse"));
 
     let project = load_project_from_cli_args(filtered_args).await?;
 


### PR DESCRIPTION
I'm already shimming arguments, might as well shim in parse. 